### PR TITLE
Increase max value for line length

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -352,6 +352,7 @@
                             "type": "number",
                             "title": "Maximum Line Length",
                             "default": 79,
+                            "max": 1024,
                             "description": "Set maximum allowed line length."
                         }
                     ]


### PR DESCRIPTION
The default max value for a stepper when undefined is 100. If it is manually set to a value greater than 100 and the up or down arrow on the stepper is clicked, it will go to 100.

Setting the max value fixes this issue.