### PR TITLE
Remove duplicated "pydocstyle" settings key

### DIFF
--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -178,9 +178,6 @@ function getSettings() {
                     "yapf": {
                         "enabled": getPreference('pyls.plugins.yapf.enabled')
                     },
-                    "pydocstyle": {
-                        "enabled": getPreference('pyls.plugins.pydocstyle.enabled')
-                    },
                     
                     // Additional Plugin Preferences
                     "pyls_mypy": {


### PR DESCRIPTION
The `"pydocstyle"` key in the settings dict is duplicated, overriding the previous (and more complete) sub-dict, making all settings for pydocstyle except "enabled" not do anything.